### PR TITLE
Allow skipping `alias_gensyms` in prettify

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -502,5 +502,5 @@ end
 
 Makes generated code generaly nicer to look at.
 """
-prettify(ex; lines = false) =
-  ex |> (lines ? identity : striplines) |> flatten |> unresolve |> resyntax |> alias_gensyms
+prettify(ex; lines = false, alias = true) =
+  ex |> (lines ? identity : striplines) |> flatten |> unresolve |> resyntax |> (alias ? alias_gensyms : identity)


### PR DESCRIPTION
Suggested here: https://github.com/FluxML/MacroTools.jl/issues/124#issuecomment-527170059

Perhaps `alias=false` could be the default after a deprecation cycle.