### PR TITLE
Update links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MacroTools.jl
 
-[![Build Status](https://travis-ci.org/MikeInnes/MacroTools.jl.svg?branch=master)](https://travis-ci.org/MikeInnes/MacroTools.jl)
-[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://mikeinnes.github.io/MacroTools.jl/stable)
+[![Build Status](https://travis-ci.org/FluxML/MacroTools.jl.svg?branch=master)](https://travis-ci.org/FluxML/MacroTools.jl)
+[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://fluxml.github.io/MacroTools.jl/stable)
 
-MacroTools provides a library of tools for working with Julia code and expressions. This includes a powerful template-matching system and code-walking tools that let you do deep transformations of code in a few lines. See the [docs](http://mikeinnes.github.io/MacroTools.jl/) for more info.
+MacroTools provides a library of tools for working with Julia code and expressions. This includes a powerful template-matching system and code-walking tools that let you do deep transformations of code in a few lines. See the [docs](http://fluxml.github.io/MacroTools.jl/) for more info.


### PR DESCRIPTION
Links in `README.md` seem to have been broken by a recent move of the repo to the FluxML organization. This PR aim at fixing the relevant links:
- [documentation](https://fluxml.github.io/MacroTools.jl/stable)
- [CI](https://travis-ci.org/MikeInnes/MacroTools.jl) (and associated badge)

I'm not sure whether there are other places where broken links would need to be fixed as well...