### PR TITLE
stop relying on sketchy Julia behavior in at-q

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -31,7 +31,9 @@ expressions are preserverd.
 See also: [`rmlines`](@ref)
 """
 macro q(ex)
-  Expr(:quote, striplines(ex))
+  # use esc here, so we don't rely on https://github.com/JuliaLang/julia/issues/37540 for
+  # interpolation to work
+  esc(Expr(:quote, striplines(ex)))
 end
 
 """


### PR DESCRIPTION
Interpolation inside `@q` currently only works because of sketchy macro hygiene behavior in quasiquotes: JuliaLang/julia#37540. This fix should be completely harmless in all Julia versions, but should fix 223 of the PkgEval failures in JuliaLang/julia#37573.