### PR TITLE
code quality improvements from JET analysis

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MacroTools"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.6"
+version = "0.5.7"
 
 [deps]
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"

--- a/src/match/match.jl
+++ b/src/match/match.jl
@@ -24,7 +24,11 @@ isbinding(s) = false
 isbinding(s::Symbol) = occursin(r"[^_]_(_str)?$", string(s))
 
 function bname(s::Symbol)
-  Symbol(Base.match(r"^@?(.*?)_+(_str)?$", string(s)).captures[1])
+  return @static if isdefined(Base, :AbstractMatch)
+    Symbol((Base.match(r"^@?(.*?)_+(_str)?$", string(s))::AbstractMatch).captures[1])
+  else
+    Symbol((Base.match(r"^@?(.*?)_+(_str)?$", string(s))::Base.RegexMatch).captures[1])
+  end
 end
 
 function match_inner(pat, ex, env)

--- a/src/structdef.jl
+++ b/src/structdef.jl
@@ -10,7 +10,7 @@ function splitstructdef(ex)
     elseif @capture(ex, mutable struct header_ body__ end)
         d[:mutable] = true
     else
-        parse_error(ex)
+        throw(ArgumentError("can't split $(repr(ex))"))
     end
     
     if @capture header nameparam_ <: super_
@@ -18,7 +18,7 @@ function splitstructdef(ex)
     elseif @capture header nameparam_
         super = :Any
     else
-        parse_error(ex)
+        throw(ArgumentError("can't split $(repr(ex))"))
     end
     d[:supertype] = super
     if @capture nameparam name_{param__}
@@ -26,7 +26,7 @@ function splitstructdef(ex)
     elseif @capture nameparam name_
         param = []
     else
-        parse_error(ex)
+        throw(ArgumentError("can't split $(repr(ex))"))
     end
     d[:name] = name
     d[:params] = param

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -417,13 +417,6 @@ function combinearg(arg_name, arg_type, is_splat, default)
     return default === nothing ? a2 : Expr(:kw, a2, default)
 end
 
-
-macro splitcombine(fundef)
-    dict = splitdef(fundef)
-    esc(rebuilddef(striplines(dict)))
-end
-
-
 """
     splitarg(arg)
 
@@ -444,11 +437,11 @@ See also: [`combinearg`](@ref)
 """
 function splitarg(arg_expr)
     splitvar(arg) =
-        @match arg begin
+        (@match arg begin
             ::T_ => (nothing, T)
             name_::T_ => (name, T)
-            x_ => (x, :Any)
-        end
+            x_ => (x, :Any) # capture every pattern
+        end)::NTuple{2,Any}
     (is_splat = @capture(arg_expr, arg_expr2_...)) || (arg_expr2 = arg_expr)
     if @capture(arg_expr2, arg_ = default_)
         @assert default !== nothing "splitarg cannot handle `nothing` as a default. Use a quoted `nothing` if possible. (MacroTools#35)"

--- a/test/split.jl
+++ b/test/split.jl
@@ -112,4 +112,5 @@ end
     @test first(constructors) ==
         :((S(a::A) where A) = new{A}()) |> MacroTools.flatten
 
+    @test_throws ArgumentError splitstructdef(:(call_ex(arg)))
 end


### PR DESCRIPTION
I ran [JET analysis](https://github.com/aviatesk/JET.jl) on this package, and fixed some true positive errors.

> run JET on `MacroTools`

```julia
julia> using JET
julia> report_file("src/MacroTools.jl"; analyze_from_definitions = true, annotate_types = true)
```

> Before this PR

```julia
═════ 11 possible errors found ═════
┌ @ src/match/match.jl:27 Base.getproperty(Base.getproperty(MacroTools.Base, :match::Symbol)::typeof(match)(r"^@?(.*?)_+(_str)?$", MacroTools.string(s::Symbol)::String)::Union{Nothing, RegexMatch}, :captures::Symbol)
│┌ @ Base.jl:33 Base.getfield(x::Nothing, f::Symbol)
││ type Nothing has no field captures
│└──────────────
┌ @ src/match/types.jl:20 MacroTools.map(MacroTools.totype, ts::Vector{Symbol})
│┌ @ abstractarray.jl:2301 Base.collect_similar(A::Vector{Symbol}, Base.Generator(f::typeof(MacroTools.totype), A::Vector{Symbol})::Base.Generator{Vector{Symbol}, typeof(MacroTools.totype)})
││┌ @ array.jl:620 Base._collect(cont::Vector{Symbol}, itr::Base.Generator{Vector{Symbol}, typeof(MacroTools.totype)}, Base.IteratorEltype(itr::Base.Generator{Vector{Symbol}, typeof(MacroTools.totype)})::Base.EltypeUnknown, Base.IteratorSize(itr::Base.Generator{Vector{Symbol}, typeof(MacroTools.totype)})::Base.HasShape{1})
│││┌ @ array.jl:710 Base.collect_to_with_first!(Base._similar_for(c::Vector{Symbol}, Base.typeof(v1::Union{Expr, Symbol})::Union{Type{Expr}, Type{Symbol}}, itr::Base.Generator{Vector{Symbol}, typeof(MacroTools.totype)}, isz::Base.HasShape{1})::Union{Vector{Expr}, Vector{Symbol}}, v1::Union{Expr, Symbol}, itr::Base.Generator{Vector{Symbol}, typeof(MacroTools.totype)}, st::Int64)
││││┌ @ array.jl:715 Base.setindex!(dest::Vector{Symbol}, v1::Expr, i1::Int64)
│││││┌ @ array.jl:853 Base.convert(_::Type{Symbol}, x::Expr)
││││││ no matching method found for call signature: Base.convert(_::Type{Symbol}, x::Expr)
│││││└────────────────
││││┌ @ array.jl:715 Base.setindex!(dest::Vector{Expr}, v1::Symbol, i1::Int64)
│││││┌ @ array.jl:853 Base.convert(_::Type{Expr}, x::Symbol)
││││││ no matching method found for call signature: Base.convert(_::Type{Expr}, x::Symbol)
│││││└────────────────
┌ @ src/utils.jl:21 Base.collect(Base.Generator(#11::MacroTools.var"#11#12", MacroTools.map(MacroTools.esc, xs::Tuple)::Any)::Base.Generator{_A, MacroTools.var"#11#12"} where _A)
│┌ @ array.jl:697 Base.collect_to_with_first!(Base._array_for(Base.typeof(v1::Expr)::Type{Expr}, Base.getproperty(itr::Base.Generator{_A, MacroTools.var"#11#12"} where _A, :iter::Symbol)::Any, isz::Any)::Any, v1::Expr, itr::Base.Generator{_A, MacroTools.var"#11#12"} where _A, st::Any)
││┌ @ array.jl:721 Base.grow_to!(dest::Any, itr::Base.Generator{_A, MacroTools.var"#11#12"} where _A, st::Any)
│││┌ @ dict.jl:153 Base.indexed_iterate(Core.getfield(Base.indexed_iterate(y::Tuple{Expr, Any}, 1)::Tuple{Expr, Int64}, 1)::Expr, 1)
││││┌ @ tuple.jl:89 Base.iterate(I::Expr)
│││││ no matching method found for call signature: Base.iterate(I::Expr)
││││└───────────────
┌ @ src/utils.jl:423 MacroTools.rebuilddef(MacroTools.striplines(dict::Dict)::Dict)
│ variable MacroTools.rebuilddef is not defined: MacroTools.rebuilddef(MacroTools.striplines(dict::Dict)::Dict)
└────────────────────
┌ @ src/utils.jl:455 Core.tuple(splitvar::MacroTools.var"#splitvar#35"(arg::Any)::Union{Nothing, Tuple{Any, Any}}, Core.tuple(is_splat::Bool, default::Any)::Tuple{Bool, Any}...)
│ no matching method found for call signature: Core.tuple(splitvar::MacroTools.var"#splitvar#35"(arg::Any)::Union{Nothing, Tuple{Any, Any}}, Core.tuple(is_splat::Bool, default::Any)::Tuple{Bool, Any}...)
└────────────────────
┌ @ src/utils.jl:457 Core.tuple(splitvar::MacroTools.var"#splitvar#35"(arg_expr2::Any)::Union{Nothing, Tuple{Any, Any}}, Core.tuple(is_splat::Bool, MacroTools.nothing)::Tuple{Bool, Nothing}...)
│ no matching method found for call signature: Core.tuple(splitvar::MacroTools.var"#splitvar#35"(arg_expr2::Any)::Union{Nothing, Tuple{Any, Any}}, Core.tuple(is_splat::Bool, MacroTools.nothing)::Tuple{Bool, Nothing}...)
└────────────────────
┌ @ src/structdef.jl:13 MacroTools.parse_error(ex::Any)
│ variable MacroTools.parse_error is not defined: MacroTools.parse_error(ex::Any)
└───────────────────────
┌ @ src/structdef.jl:21 MacroTools.parse_error(ex::Any)
│ variable MacroTools.parse_error is not defined: MacroTools.parse_error(ex::Any)
└───────────────────────
┌ @ src/structdef.jl:29 MacroTools.parse_error(ex::Any)
│ variable MacroTools.parse_error is not defined: MacroTools.parse_error(ex::Any)
└───────────────────────
┌ @ src/examples/destruct.jl:24 MacroTools.error("Can't destructure fields with default values")
│┌ @ error.jl:33 error(::String)
││ may throw: Base.throw($(Expr(:invoke, MethodInstance for ErrorException(::String), :(Base.ErrorException), Core.Argument(2)))::ErrorException)
│└───────────────
```

> After this PR: only the false positives ramain (Julia's inference or JET itself should be improved)

```julia
═════ 4 possible errors found ═════
┌ @ src/match/types.jl:20 MacroTools.map(MacroTools.totype, ts::Vector{Symbol})
│┌ @ abstractarray.jl:2301 Base.collect_similar(A::Vector{Symbol}, Base.Generator(f::typeof(MacroTools.totype), A::Vector{Symbol})::Base.Generator{Vector{Symbol}, typeof(MacroTools.totype)})
││┌ @ array.jl:620 Base._collect(cont::Vector{Symbol}, itr::Base.Generator{Vector{Symbol}, typeof(MacroTools.totype)}, Base.IteratorEltype(itr::Base.Generator{Vector{Symbol}, typeof(MacroTools.totype)})::Base.EltypeUnknown, Base.IteratorSize(itr::Base.Generator{Vector{Symbol}, typeof(MacroTools.totype)})::Base.HasShape{1})
│││┌ @ array.jl:710 Base.collect_to_with_first!(Base._similar_for(c::Vector{Symbol}, Base.typeof(v1::Union{Expr, Symbol})::Union{Type{Expr}, Type{Symbol}}, itr::Base.Generator{Vector{Symbol}, typeof(MacroTools.totype)}, isz::Base.HasShape{1})::Union{Vector{Expr}, Vector{Symbol}}, v1::Union{Expr, Symbol}, itr::Base.Generator{Vector{Symbol}, typeof(MacroTools.totype)}, st::Int64)
││││┌ @ array.jl:715 Base.setindex!(dest::Vector{Symbol}, v1::Expr, i1::Int64)
│││││┌ @ array.jl:853 Base.convert(_::Type{Symbol}, x::Expr)
││││││ no matching method found for call signature: Base.convert(_::Type{Symbol}, x::Expr)
│││││└────────────────
││││┌ @ array.jl:715 Base.setindex!(dest::Vector{Expr}, v1::Symbol, i1::Int64)
│││││┌ @ array.jl:853 Base.convert(_::Type{Expr}, x::Symbol)
││││││ no matching method found for call signature: Base.convert(_::Type{Expr}, x::Symbol)
│││││└────────────────
┌ @ src/utils.jl:21 Base.collect(Base.Generator(#11::MacroTools.var"#11#12", MacroTools.map(MacroTools.esc, xs::Tuple)::Any)::Base.Generator{_A, MacroTools.var"#11#12"} where _A)
│┌ @ array.jl:697 Base.collect_to_with_first!(Base._array_for(Base.typeof(v1::Expr)::Type{Expr}, Base.getproperty(itr::Base.Generator{_A, MacroTools.var"#11#12"} where _A, :iter::Symbol)::Any, isz::Any)::Any, v1::Expr, itr::Base.Generator{_A, MacroTools.var"#11#12"} where _A, st::Any)
││┌ @ array.jl:721 Base.grow_to!(dest::Any, itr::Base.Generator{_A, MacroTools.var"#11#12"} where _A, st::Any)
│││┌ @ dict.jl:153 Base.indexed_iterate(Core.getfield(Base.indexed_iterate(y::Tuple{Expr, Any}, 1)::Tuple{Expr, Int64}, 1)::Expr, 1)
││││┌ @ tuple.jl:89 Base.iterate(I::Expr)
│││││ no matching method found for call signature: Base.iterate(I::Expr)
││││└───────────────
┌ @ src/examples/destruct.jl:24 MacroTools.error("Can't destructure fields with default values")
│┌ @ error.jl:33 error(::String)
││ may throw: Base.throw($(Expr(:invoke, MethodInstance for ErrorException(::String), :(Base.ErrorException), Core.Argument(2)))::ErrorException)
│└───────────────
```