### PR TITLE
make "slurp" pattern configurable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MacroTools"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.6"
+version = "0.5.7"
 
 [deps]
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"

--- a/test/match.jl
+++ b/test/match.jl
@@ -96,3 +96,18 @@ let
   @capture(ex, $f(args__))
   @test args == [:a, :b]
 end
+
+# configurable "slurp" pattern
+let
+  try
+    pat = :(__init__())
+
+    @test isempty(MacroTools.IGNORED_SLURP_PATTERNS) # `IGNORED_SLURP_PATTERNS` should be empty by default
+    @test (@capture(:(foo()), $pat), @capture(:(__init__()), $pat)) == (true, true)
+
+    push!(MacroTools.IGNORED_SLURP_PATTERNS, :__init__)
+    @test (@capture(:(foo()), $pat), @capture(:(__init__()), $pat)) == (false, true)
+  finally
+    empty!(MacroTools.IGNORED_SLURP_PATTERNS) # clean up
+  end
+end


### PR DESCRIPTION
This PR setups `IGNORED_SLURP_PATTERNS::Set{Symbol}`, which allows users
to configure patterns that should _not_ be recognized as "slurp"s.

The motivation here is that there can be double-scores in variable names
and so we sometimes may want them not to be recognized as "slurp" pattern.

For example, let's consider when we want to specify a pattern that _only_
matches `__init__()` expression:
```julia
julia> @capture(:(__init__()), __init__()), @capture(:(foo()), __init__()) # you may want the latter case not to match
(true, true)
```
With this PR, we can configure `IGNORED_SLURP_PATTERNS` and achieve what
we want:
```julia
julia> push!(MacroTools.IGNORED_SLURP_PATTERNS, :__init__); # configure `IGNORED_SLURP_PATTERNS`

julia> @capture(:(__init__()), __init__()), @capture(:(foo()), __init__()) # now `__init__` isn't recognized as slurp pattern
(true, false)
```

`IGNORED_SLURP_PATTERNS` is initialized as an empty set, and thus this
change doesn't break any existing behavior by default.