### PR TITLE
Improve inferrability of isor

### DIFF
--- a/src/match/union.jl
+++ b/src/match/union.jl
@@ -11,7 +11,13 @@ function match_inner(pat::OrBind, ex, env)
   env′ == nothing ? match(pat.pat2, ex, env) : merge!(env, env′)
 end
 
-isor(ex) = isexpr(ex, :call) && ex.args[1] in (:or_, :|)
+function isor(ex)
+  if isexpr(ex, :call)
+    arg1 = ex.args[1]
+    return arg1 isa Symbol && arg1 in (:or_, :|)
+  end
+  return false
+end
 
 function ornew(ex)
   isor(ex) || return ex

--- a/src/match/union.jl
+++ b/src/match/union.jl
@@ -14,7 +14,7 @@ end
 function isor(ex)
   if isexpr(ex, :call)
     arg1 = ex.args[1]
-    return arg1 isa Symbol && arg1 in (:or_, :|)
+    return arg1 isa Symbol && arg1 in (:or_, :|)    # to improve inferrability, see #166
   end
   return false
 end


### PR DESCRIPTION
This avoids invalidations of `in` or `==` for Symbols.

There are several other inferrability issues with this package, `unblock` being a real champion source, which may essentially be unfixable. Consequently users of this package may have to be prepared for a certain amount of precompile failures.

CC @ChrisRackauckas. 