### PR TITLE
add dict interface splitargdef and combineargdef

### DIFF
--- a/test/split.jl
+++ b/test/split.jl
@@ -11,6 +11,13 @@ macro splitcombine(fundef) # should be a no-op
     esc(MacroTools.combinedef(dict))
 end
 
+macro splitcombine2(fundef) # should be a no-op
+    dict = splitdef(fundef)
+    dict[:args] = map(arg->combineargdef(splitargdef(arg)), dict[:args])
+    dict[:kwargs] = map(arg->combineargdef(splitargdef(arg)), dict[:kwargs])
+    esc(MacroTools.combinedef(dict))
+end
+
 # Macros for testing that splitcombine doesn't break
 # macrocalls in bodies
 macro zeroarg()
@@ -29,14 +36,22 @@ let
     @test map(splitarg, (:(f(a=2, x::Int=nothing, y::Any, args...))).args[2:end]) ==
         [(:a, :Any, false, 2), (:x, :Int, false, :nothing),
          (:y, :Any, false, nothing), (:args, :Any, true, nothing)]
+    @test map(splitargdef, (:(f(a=2, x::Int=nothing, y::Any, args...))).args[2:end]) ==
+        [Dict(:name=>:a, :is_splat=>false, :default=>2), Dict(:name=>:x, :type=>:Int, :is_splat=>false, :default=>:nothing),
+         Dict(:name=>:y, :type=>:Any, :is_splat=>false), Dict(:name=>:args, :is_splat=>true)]
     @test splitarg(:(::Int)) == (nothing, :Int, false, nothing)
+    @test splitargdef(:(::Int)) == Dict(:type=>:Int, :is_splat=>false)
     kwargs = splitdef(:(f(; a::Int = 1, b...) = 1))[:kwargs]
     @test map(splitarg, kwargs) ==
         [(:a, :Int, false, 1), (:b, :Any, true, nothing)]
+    @test map(splitargdef, kwargs) ==
+        [Dict(:name=>:a, :type=>:Int, :is_splat=>false, :default=>1), Dict(:name=>:b, :is_splat=>true)]
     args = splitdef(:(f(a::Int = 1) = 1))[:args]
     @test map(splitarg, args) == [(:a, :Int, false, 1)]
+    @test map(splitargdef, args) == [Dict(:name=>:a, :type=>:Int, :is_splat=>false, :default=>1)]
     args = splitdef(:(f(a::Int ... = 1) = 1))[:args]
     @test map(splitarg, args) == [(:a, :Int, true, 1)]    # issue 165 
+    @test map(splitargdef, args) == [Dict(:name=>:a, :type=>:Int, :is_splat=>true, :default=>1)]    # issue 165 
 
     @splitcombine foo(x) = x+2
     @test foo(10) == 12
@@ -81,6 +96,54 @@ let
     @test (@splitcombine function (x) x + 2 end)(10) === 12
     @test (@splitcombine function (a::T) where {T} T end)([]) === Vector{Any}
     @test (@splitcombine function (x::T, y::Vector{U}) where T <: U where U
+               (T, U)
+           end)(1, Number[2.0]) == (Int, Number)
+end
+
+let
+    @splitcombine2 foo(x) = x+2
+    @test foo(10) == 12
+    @splitcombine2 add(a, b=2; c=3, d=4)::Float64 = a+b+c+d
+    @test add(1; d=10) === 16.0
+    @splitcombine2 fparam(a::T) where {T} = T
+    @test fparam([]) == Vector{Any}
+    struct Orange end
+    @splitcombine2 (::Orange)(x) = x+2
+    @test Orange()(10) == 12
+    @splitcombine2 fwhere(a::T) where T = T
+    @test fwhere(10) == Int
+    @splitcombine2 manywhere(x::T, y::Vector{U}) where T <: U where U = (T, U)
+    @test manywhere(1, Number[2.0]) == (Int, Number)
+    @splitcombine2 fmacro0() = @zeroarg
+    @test fmacro0() == 1
+    @splitcombine2 fmacro1() = @onearg 1
+    @test fmacro1() == 2
+
+    @splitcombine2 bar(; a::Int = 1, b...) = 2
+    @test bar(a=3, x = 1, y = 2) == 2
+    @splitcombine2 qux(a::Int... = 0) = sum(a)
+    @test qux(1, 2, 3) == 6
+    @test qux() == 0
+
+    struct Foo{A, B}
+        a::A
+        b::B
+    end
+    # Parametric outer constructor
+    @splitcombine2 Foo{A}(a::A) where A = Foo{A, A}(a,a)
+    @test Foo{Int}(2) == Foo{Int, Int}(2, 2)
+
+    @test (@splitcombine2 x -> x + 2)(10) === 12
+    @test (@splitcombine2 (a, b=2; c=3, d=4) -> a+b+c+d)(1; d=10) === 16
+    @test (@splitcombine2 ((a, b)::Tuple{Int,Int} -> a + b))((1, 2)) == 3
+    @test (@splitcombine2 ((a::T) where {T}) -> T)([]) === Vector{Any}
+    @test (@splitcombine2 ((x::T, y::Vector{U}) where T <: U where U) -> (T, U))(1, Number[2.0]) ==
+          (Int, Number)
+    @test (@splitcombine2 () -> @zeroarg)() == 1
+    @test (@splitcombine2 () -> @onearg 1)() == 2
+    @test (@splitcombine2 function (x) x + 2 end)(10) === 12
+    @test (@splitcombine2 function (a::T) where {T} T end)([]) === Vector{Any}
+    @test (@splitcombine2 function (x::T, y::Vector{U}) where T <: U where U
                (T, U)
            end)(1, Number[2.0]) == (Int, Number)
 end


### PR DESCRIPTION
This PR adds new methods `splitargdef` and `combineargdef` (in addition to existing `splitarg` and `combinearg`) that use dictionaries as an interface. The dict interface more completely expresses corner cases, as described in https://github.com/FluxML/MacroTools.jl/pull/178. In particular, it provides robust solutions for literal `nothing` argument defaults and avoids typeasserts when no type is given for an argument.