### PR TITLE
Throw an error when encountering missing values

### DIFF
--- a/src/match/match.jl
+++ b/src/match/match.jl
@@ -16,6 +16,7 @@ macro trymatch(ex)
 end
 
 function store!(env, name, ex)
+  ismissing(ex) && error("Pattern matching doesn't currently support missing values.")
   haskey(env, name) && !(env[name] == ex) && @nomatch(name, ex)
   assoc!(env, name, ex)
 end


### PR DESCRIPTION
JET.jl rightly notes that this function will error if a `missing` appears inside an expression, and we try to bind it. This is certainly an edge case (and clearly no-one's hit it so far), but strictly speaking `missing` is allowed in `Expr`s, and the internal error isn't ideal if someone does hit it. So I've added an explicit error. In future we could add support (probably by assuming `missing == missing` for the purposes of this check).

Unfortunately, JET/Julia's inference isn't smart enough to figure out that the missing-boolean error no longer applies. Is there some way to assert that `env[name]::!Missing`, ie anything other than missing? A type assert would be ok, but I'd be a bit reluctant to do anything more complex that sacrifices readability.