### PR TITLE
add manual `workflow_dispatch`

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -6,6 +6,7 @@ on:
     tags: '*'
   pull_request:
     paths: ['docs/**']
+  workflow_dispatch:
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Follow up of https://github.com/FluxML/MacroTools.jl/pull/189.

https://fluxml.ai/MacroTools.jl/dev looks good and was deployed correctly, now we need to run the documentation workflow on previous tags manually, this is what `workflow_dispatch` allows.

@cstjean, after this PR is merged, you can go to the [`Actions` tab](https://github.com/FluxML/MacroTools.jl/actions) -> `Documentation` on the left -> `Run workflow` on the right -> `Branch master` (select `Tags` tab) -> select `v0.5.10` -> and finally click `Run workflow`: it should build the docs for https://fluxml.ai/MacroTools.jl/stable (which now points to the obsolete `v0.5.4` tag).

### PR Checklist

- [x] Documentation, if applicable
