### PR TITLE
Define @qq

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
           - 'nightly'
         os: [ubuntu-latest, macOS-latest, windows-latest]

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-julia = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MacroTools"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.12"
+version = "0.5.13"
 
 [deps]
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -43,6 +43,7 @@ MacroTools.combinearg
 
 ```@docs
 MacroTools.@q
+MacroTools.@qq
 MacroTools.isexpr
 MacroTools.rmlines
 MacroTools.unblock

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,4 +1,4 @@
-using MacroTools: isdef, flatten, striplines
+using MacroTools: isdef, flatten, striplines, @qq
 
 @testset "utils" begin
     ex1 = :(function foo(a) return a; end)
@@ -45,3 +45,17 @@ end
         @test flatten(ex) |> striplines == ex |> striplines
     end
 end
+
+## Test for @qq
+
+macro my_fff_def(a)
+    @qq function fff() $a end
+end
+
+@my_fff_def begin   # line where fff() is defined
+    function g()    # line where fff()() is defined
+        22
+    end
+end
+
+@test which(fff,()).line == which(fff(),()).line - 1


### PR DESCRIPTION
I found it pretty hard to write the docstring, improvements are welcome.

```julia
julia> macro my_fff_def(a)
           @qq function fff() $a end
       end
@my_fff_def (macro with 1 method)

julia> @macroexpand @my_fff_def begin   # line where fff() is defined
           function g()    # line where fff()() is defined
               22
           end
       end
:(function Main.fff()
      #= REPL[46]:1 =#          # with normal quotation, this line is from the macro construction site
      #= REPL[46]:1 =#
      begin
          #= REPL[46]:2 =#
          function var"#82#g"()
              #= REPL[46]:2 =#
              #= REPL[46]:3 =#
              22
          end
      end
  end)
```