### PR TITLE
remove markdown from dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,8 @@
 name = "MacroTools"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.13"
+version = "0.5.14"
 
 [deps]
-Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]

--- a/src/MacroTools.jl
+++ b/src/MacroTools.jl
@@ -1,6 +1,6 @@
 module MacroTools
 
-using Markdown, Random
+using Random
 export @match, @capture
 
 include("match/match.jl")


### PR DESCRIPTION
At first glance, seems that `Markdown` is being loaded but not used in the package.
this PR was done in the context of https://github.com/JuliaFolds2/Transducers.jl/issues/35