### PR TITLE
Fix anonymous function edge cases

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -262,7 +262,7 @@ function longdef1(ex)
 
     if isexpr(arg, :tuple) && length(arg.args) == 1 && isexpr(arg.args[1], :parameters)
       # Special case (; kws...) ->
-      fcall = Expr(:call, :tuple, arg.args[1])
+      fcall = Expr(:tuple, arg.args[1])
 
       Expr(:function, fcall, body)
     elseif isexpr(arg, :block) && any(a -> isexpr(a, :...) || isexpr(a, :(=)) || isexpr(a, :kw), arg.args)
@@ -278,7 +278,7 @@ function longdef1(ex)
           end
         end
       end
-      fcall = Expr(:call, :tuple, Expr(:parameters, kw_args...), pos_args...)
+      fcall = Expr(:tuple, Expr(:parameters, kw_args...), pos_args...)
 
       Expr(:function, fcall, body)
     elseif isexpr(arg, :...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -351,8 +351,13 @@ function splitdef(fdef)
                               (func_(args__)) |
                               (func_(args__)::rtype_)))
   elseif isexpr(fcall_nowhere, :tuple)
-    if length(fcall_nowhere.args) > 1 && isexpr(fcall_nowhere.args[1], :parameters)
-      args = fcall_nowhere.args[2:end]
+    if length(fcall_nowhere.args) > 0 && isexpr(fcall_nowhere.args[1], :parameters)
+      # Handle both cases: parameters with args and parameters only
+      if length(fcall_nowhere.args) > 1
+        args = fcall_nowhere.args[2:end]
+      else
+        args = []
+      end
       kwargs = fcall_nowhere.args[1].args
     else
       args = fcall_nowhere.args

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -271,7 +271,12 @@ function longdef1(ex)
       kw_args = []
       for a in arg.args
         if !(a isa LineNumberNode)
-          if isexpr(a, :...) || isexpr(a, :(=)) || isexpr(a, :kw)
+          if isexpr(a, :...)
+            push!(kw_args, a)
+          elseif isexpr(a, :(=))
+            # Transform = to :kw for keyword arguments
+            push!(kw_args, Expr(:kw, a.args[1], a.args[2]))
+          elseif isexpr(a, :kw)
             push!(kw_args, a)
           else
             push!(pos_args, a)

--- a/test/split.jl
+++ b/test/split.jl
@@ -115,6 +115,14 @@ let
     # Both splatted positional and keyword arguments
     @test (@splitcombine (a::Int, args::Int...; kws...) -> a + sum(args) + sum(values(kws)))(1, 2, 3; b=4, c=5) == 15
     @test (@splitcombine (a, ::Int...; b, kws...) -> a + sum(values(kws)))(1, 2, 3; b=4, c=5) == 1 + 5
+
+    # Issue with longdef
+    ex = longdef(:((a::Int; b=2) -> a + b))
+    any_kw(ex) = ex isa Expr ? (any_kw(ex.head) || any(any_kw, ex.args)) : ex == :kw
+    @test any_kw(ex)
+    ## ^Ensure we get a :kw expression in the output AST
+    @test eval(ex) isa Function
+    ## Shouldn't have issues evaluating
 end
 
 @testset "combinestructdef, splitstructdef" begin


### PR DESCRIPTION
This fixes a few classes of anonymous functions that could not be parsed before. @cstjean do you think you could review this? I really need this patch to address some major bugs for BorrowChecker.jl and DispatchDoctor.jl, which both depend on MacroTools.jl for function parsing.

This Fixes #209 Fixes #185 


## More notes

Here are some functions that could not be parsed with `splitdef` before this change, but now work:

- `(a::Int; b=2) -> 1`
- `(args...) -> 1`
- `(arg; kws...) -> 1`

All of these functions hit the error

```julia
ERROR: AssertionError: Not a function definition: begin
```

but now they can parse fine:

```julia
julia> splitdef(quote; (a::Int; b=2) -> 1; end)
Dict{Symbol, Any} with 4 entries:
  :args        => Any[:(a::Int)]
  :body        => quote…
  :kwargs      => Any[:(b = 2)]
  :whereparams => ()

julia> splitdef(quote; (args...) -> 1; end)
Dict{Symbol, Any} with 4 entries:
  :args        => Any[:(args...)]
  :body        => quote…
  :kwargs      => Any[]
  :whereparams => ()

julia> splitdef(quote; (arg; kws...) -> 1; end)
Dict{Symbol, Any} with 4 entries:
  :args        => Any[:arg]
  :body        => quote…
  :kwargs      => Any[:(kws...)]
  :whereparams => ()
```

I've verified 100% test coverage of the code diff. I've also verified all the existing tests pass.

## PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable
