### PR TITLE
Test correct `:params` in `splitdef` on constructor

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -334,7 +334,7 @@ end
 Match any function definition
 
 ```julia
-function name{params}(args; kwargs)::rtype where {whereparams}
+function name{params}(args; kwargs)::rtype where {whereparams} # `params` is used in constructors
    body
 end
 ```

--- a/test/split.jl
+++ b/test/split.jl
@@ -98,6 +98,9 @@ let
     @test (@splitcombine ((c, (a, b); d=1) -> a + b + c + d))(3, (1, 2); d=4) === 10
     @test (@splitcombine ((c, (a, b); d) -> a + b + c + d))(3, (1, 2); d=4) === 10
 
+    # With params (constructor)
+    @test splitdef(Meta.parse("A{Float64}(t::T) where {T} = 1"))[:params] == [:Float64]
+
     # Test for single varargs argument in lambda
     @test splitdef(Meta.parse("(args...) -> 0"))[:args] == [:(args...)]
     @test (@splitcombine (args...) -> sum(args))(1, 2, 3) == 6


### PR DESCRIPTION
When looking at the documentation, I did not immediately realize that `:params` are used in constructors. I added a note
about that for users with the same question.
While exploring the package, I noticed that there is not test of correct `:params` detection on `splitdef` so I added
one.

Summary:
- Added a note to the documentation on the purpose of `params`
- Added a test to check that the detection of `:params` works in `splitdef`
